### PR TITLE
Add crates & docs badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![](https://img.shields.io/crates/v/line_drawing.svg)](https://crates.io/crates/line_drawing)
+[![](https://docs.rs/line_drawing/badge.svg)](https://docs.rs/line_drawing)
+
 A collection of line-drawing algorithms for use in graphics and video games.
 
 Currently implemented:


### PR DESCRIPTION
This makes it easier to find the documentation and see the current version to include in `Cargo.toml`.