### PR TITLE
Update image to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ num-traits = "0.1.40"
 
 [dev-dependencies]
 bresenham = "0.1.1"
-image = "0.17.0"
+image = { version = "0.23.0", default-features = false, features = ["png"] }
 rand = "0.6"

--- a/examples/basic_shapes.rs
+++ b/examples/basic_shapes.rs
@@ -1,6 +1,5 @@
 //! An example of generating basic shapes
 extern crate image;
-extern crate num_complex;
 extern crate line_drawing;
 
 fn draw_circle(imgbuf: &mut image::RgbaImage, xc: i32, yc: i32, r: i32) {

--- a/examples/scale_up.rs
+++ b/examples/scale_up.rs
@@ -2,7 +2,7 @@ extern crate image;
 extern crate line_drawing;
 
 use line_drawing::*;
-use image::*;
+use image::{DynamicImage, GenericImage, imageops::FilterType, Rgba};
 
 const BLACK: [u8; 4] = [255, 255, 255, 255];
 const GREY: [u8; 4] = [128, 128, 128, 255];


### PR DESCRIPTION
This also minimizes the number of features and dependencies as only png
encoding is required to run the examples (please re-check this).