### PR TITLE
update num-traits to 0.2 and bump version to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "line_drawing"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Expenses <expenses@airmail.cc>"]
 description = "A collection of line-drawing algorithms for use in graphics and video games."
 repository = "https://github.com/expenses/line_drawing"
@@ -12,7 +12,7 @@ readme = "README.md"
 
 
 [dependencies]
-num-traits = "0.1.40"
+num-traits = "0.2"
 
 [dev-dependencies]
 bresenham = "0.1.1"


### PR DESCRIPTION
Hello! I have updated num traits to 0.2, since 0.1 is quite old.

Please can we have a crates release asap? This is only crate in large dep tree that pulls in old num traits, so it will be very helpful to remove, thank you!