### PR TITLE
Add proper no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 
 [dependencies]
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 
 [dev-dependencies]
 bresenham = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 
 [dependencies]
-num-traits = { version = "0.2", default-features = false }
+num-traits = { version = "0.2", default-features = false, features = ['libm'] }
 
 [dev-dependencies]
 bresenham = "0.1.1"


### PR DESCRIPTION
Hello! I was attempting to use this crate with no_std, and had issues compiling since num_traits still had the std feature enabled. Thankfully, enabling the libm feature allows this crate to continue using num_traits as is, now with actual no_std support. I've verified this compiles and runs properly on an stm32f7 with this fix.